### PR TITLE
Add SmallWebAPI subtypeID

### DIFF
--- a/WebAPIMod/CubeBlocks.sbc
+++ b/WebAPIMod/CubeBlocks.sbc
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <CubeBlocks>
+    <Definition xsi:type="MyObjectBuilder_TextPanelDefinition">
+      <Id>
+        <TypeId>TextPanel</TypeId>
+        <SubtypeId>WebAPI</SubtypeId>
+      </Id>
+      <DisplayName>WebAPI Block</DisplayName>
+      <Icon>Textures\GUI\Icons\Fake.dds</Icon>
+      <CubeSize>Large</CubeSize>
+      <BlockTopology>TriangleMesh</BlockTopology>
+      <Size x="1" y="1" z="1" />
+      <ModelOffset x="0" y="0" z="0" />
+      <Model>Models\Cubes\Large\LCDPanel.mwm</Model>
+      <Components>
+        <Component Subtype="Construction" Count="4" />
+        <Component Subtype="Computer" Count="4" />
+        <Component Subtype="Display" Count="3" />
+      </Components>
+      <CriticalComponent Subtype="Computer" Index="0" />
+      <MountPoints>
+        <MountPoint Side="Front" StartX="0" StartY="0" EndX="1" EndY="1" />
+        <MountPoint Side="Left" StartX="0" StartY="0" EndX="0.1" EndY="1" />
+        <MountPoint Side="Right" StartX="0.9" StartY="0" EndX="1" EndY="1" />
+        <MountPoint Side="Top" StartX="0" StartY="0.9" EndX="1" EndY="1" />
+        <MountPoint Side="Bottom" StartX="0" StartY="0" EndX="1" EndY="0.1" />
+      </MountPoints>
+      <BuildProgressModels>
+        <Model BuildPercentUpperBound="1.00" File="Models\Cubes\small\TextPanel_Construction_1.mwm" />
+      </BuildProgressModels>
+      <BlockPairName>WebAPI</BlockPairName>
+      <MirroringZ>Y</MirroringZ>
+      <EdgeType>Light</EdgeType>
+      <BuildTimeSeconds>3</BuildTimeSeconds>
+      <DamageEffectId>214</DamageEffectId>
+      <DamagedSound>ParticleElectrical</DamagedSound>
+      <ResourceSinkGroup>Utility</ResourceSinkGroup>
+      <RequiredPowerInput>0.00002</RequiredPowerInput>
+    </Definition>
+
+    <Definition xsi:type="MyObjectBuilder_TextPanelDefinition">
+      <Id>
+        <TypeId>TextPanel</TypeId>
+        <SubtypeId>SmallWebAPI</SubtypeId>
+      </Id>
+      <DisplayName>WebAPI Block</DisplayName>
+      <Icon>Textures\GUI\Icons\Fake.dds</Icon>
+      <CubeSize>Small</CubeSize>
+      <BlockTopology>TriangleMesh</BlockTopology>
+      <Size x="1" y="1" z="1" />
+      <ModelOffset x="0" y="0" z="0" />
+      <Model>Models\Cubes\Small\TextPanel.mwm</Model>
+      <Components>
+        <Component Subtype="Construction" Count="4" />
+        <Component Subtype="Computer" Count="4" />
+        <Component Subtype="Display" Count="3" />
+      </Components>
+      <CriticalComponent Subtype="Computer" Index="0" />
+      <MountPoints>
+        <MountPoint Side="Front" StartX="0" StartY="0" EndX="1" EndY="1" />
+        <MountPoint Side="Left" StartX="0" StartY="0" EndX="0.1" EndY="1" />
+        <MountPoint Side="Right" StartX="0.9" StartY="0" EndX="1" EndY="1" />
+        <MountPoint Side="Top" StartX="0" StartY="0.9" EndX="1" EndY="1" />
+        <MountPoint Side="Bottom" StartX="0" StartY="0" EndX="1" EndY="0.1" />
+      </MountPoints>
+      <BuildProgressModels>
+        <Model BuildPercentUpperBound="1.00" File="Models\Cubes\small\TextPanel_Construction_1.mwm" />
+      </BuildProgressModels>
+      <BlockPairName>WebAPI</BlockPairName>
+      <MirroringZ>Y</MirroringZ>
+      <EdgeType>Light</EdgeType>
+      <BuildTimeSeconds>3</BuildTimeSeconds>
+      <DamageEffectId>214</DamageEffectId>
+      <DamagedSound>ParticleElectrical</DamagedSound>
+      <ResourceSinkGroup>Utility</ResourceSinkGroup>
+      <RequiredPowerInput>0.00002</RequiredPowerInput>
+    </Definition>
+
+  </CubeBlocks>
+</Definitions>

--- a/WebAPIMod/SEWATerminal.cs
+++ b/WebAPIMod/SEWATerminal.cs
@@ -25,7 +25,7 @@ namespace WebAPIMod
 
         private void ControlGetter(IMyTerminalBlock block, List<IMyTerminalControl> controls)
         {
-            if (block.BlockDefinition.SubtypeId == "WebAPI")
+            if (block.BlockDefinition.SubtypeId == "WebAPI" || block.BlockDefinition.SubtypeId == "SmallWebAPI" )
             {
                 //Remove default LCD controls except for the on/off toggles.
                 controls.RemoveAll(x => !(x is IMyTerminalControlOnOffSwitch));


### PR DESCRIPTION
## Synopsis

I need to be able to place webapi block onto a small grid, so I've made the changes here and tested with 662477070 locally modified -- though I obviously can't test it with a DS without uploading to workshop and I wanted your review first.  
## Questions

I see that \Data\Scripts\ClientInterface\WebAPIBlock.cs (from the mod off workshop) and SEWebAPI\SEWATerminal.cs (updated here) seem to be revisions of one another (the one in repo being newer), but since I don't know how you packaged up 662477070.sbm (or why the workshop would have older code).  If I'm wrong in my assumptions, can you educate me on what is going on there?

Also, I didn't see CubeBlock from 662477070.sbm anywhere in the repo, so I added it here.   Where is the right place to put it if not here?  
## Acceptable caveats

This uses the model from "TextPanel" (not lcd panel) for small grids.  This may have limiting features, but that's okay too.  

This may very well not work with QR code on textpanel, but that's okay for my testing, as I just need to be able to place SEWA mod api block onto small grid and pull the API key from control panel. 
